### PR TITLE
feat: enable Azure AD auth for storage account instead of access keys

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -24,5 +24,6 @@ terraform {
 
 provider "azurerm" {
   features {}
+  storage_use_azuread = true
 }
 


### PR DESCRIPTION
This will default all new landing zones to access storage accounts using Entra ID instead of the shared key auth