### PR TITLE
fix: remove unused variable environment_name

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -3,11 +3,6 @@ variable "station_id" {
   description = "The id of the workload deployment"
 }
 
-variable "environment_name" {
-  type        = string
-  description = "The name of the workload deployment"
-}
-
 variable "workload_resource_group_name" {
   type        = string
   description = "The name of the resource group for the workload deployment"


### PR DESCRIPTION
Removal of unused variable that is no longer provided by the Terraform module output.  
The module update made this value obsolete, so it is safe to remove.
